### PR TITLE
refactor: 뱃지 관련 삭제 #17

### DIFF
--- a/NaOng/NaOng/NotificationListView/View/NotificationListView.swift
+++ b/NaOng/NaOng/NotificationListView/View/NotificationListView.swift
@@ -44,18 +44,6 @@ struct NotificationListView: View {
             .onAppear {
                 notificationListViewModel.bind()
             }
-            .navigationBarBackButtonHidden(true)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button {
-                        notificationListViewModel.clearDeliveredNotification()
-                    } label: {
-                        Text("모두 읽음 표시")
-                            .font(.custom("Binggrae", size: 15))
-                            .foregroundColor(.black)
-                    }
-                }
-            }
             .alert(isPresented: $notificationListViewModel.showErrorAlert) {
                 Alert(
                     title: Text(notificationListViewModel.errorTitle),

--- a/NaOng/NaOng/NotificationListView/ViewModel/NotificationListViewModel.swift
+++ b/NaOng/NaOng/NotificationListView/ViewModel/NotificationListViewModel.swift
@@ -60,10 +60,6 @@ class NotificationListViewModel: NSObject, ObservableObject, NSFetchedResultsCon
             }
             .store(in: &cancellables)
     }
-    
-    func clearDeliveredNotification() {
-        localNotificationManager.removeAllDeliveredNotification()
-    }
 
     private func modifyToDoForDisplayOnNotificationView(id: String) {
         let fetchRequest: NSFetchRequest<ToDo> = ToDo.fetchRequest()


### PR DESCRIPTION
- 알림 목록 뷰에서 모두 읽음 버튼과 기능 삭제함
- 알림 생성 시, 뱃지 숫자를 nil로 수정함
- getPendingNotificationRequests를 이용하여 id 가져오는 대신, 바로 previousPendingNotificationsID에 추가하도록 수정함